### PR TITLE
Introduce DataFrameAsset.metadata

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:3e1b35aed55969fb54b18127107da9435acc4931f24841d779bdd260a79c2528"
+content_hash = "sha256:5ab9ba1ca071909f99701fa39ec8dd64891ad037b14697fbbd881941575a2e4c"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -1210,4 +1210,44 @@ dependencies = [
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
+]
+
+[[package]]
+name = "xxhash"
+version = "3.5.0"
+requires_python = ">=3.7"
+summary = "Python binding for xxHash"
+groups = ["default"]
+files = [
+    {file = "xxhash-3.5.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:14470ace8bd3b5d51318782cd94e6f94431974f16cb3b8dc15d52f3b69df8e00"},
+    {file = "xxhash-3.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:59aa1203de1cb96dbeab595ded0ad0c0056bb2245ae11fac11c0ceea861382b9"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08424f6648526076e28fae6ea2806c0a7d504b9ef05ae61d196d571e5c879c84"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:61a1ff00674879725b194695e17f23d3248998b843eb5e933007ca743310f793"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2f2c61bee5844d41c3eb015ac652a0229e901074951ae48581d58bfb2ba01be"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d32a592cac88d18cc09a89172e1c32d7f2a6e516c3dfde1b9adb90ab5df54a6"},
+    {file = "xxhash-3.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70dabf941dede727cca579e8c205e61121afc9b28516752fd65724be1355cc90"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e5d0ddaca65ecca9c10dcf01730165fd858533d0be84c75c327487c37a906a27"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3e5b5e16c5a480fe5f59f56c30abdeba09ffd75da8d13f6b9b6fd224d0b4d0a2"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149b7914451eb154b3dfaa721315117ea1dac2cc55a01bfbd4df7c68c5dd683d"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:eade977f5c96c677035ff39c56ac74d851b1cca7d607ab3d8f23c6b859379cab"},
+    {file = "xxhash-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fa9f547bd98f5553d03160967866a71056a60960be00356a15ecc44efb40ba8e"},
+    {file = "xxhash-3.5.0-cp312-cp312-win32.whl", hash = "sha256:f7b58d1fd3551b8c80a971199543379be1cee3d0d409e1f6d8b01c1a2eebf1f8"},
+    {file = "xxhash-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:fa0cafd3a2af231b4e113fba24a65d7922af91aeb23774a8b78228e6cd785e3e"},
+    {file = "xxhash-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:586886c7e89cb9828bcd8a5686b12e161368e0064d040e225e72607b43858ba2"},
+    {file = "xxhash-3.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37889a0d13b0b7d739cfc128b1c902f04e32de17b33d74b637ad42f1c55101f6"},
+    {file = "xxhash-3.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:97a662338797c660178e682f3bc180277b9569a59abfb5925e8620fba00b9fc5"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f85e0108d51092bdda90672476c7d909c04ada6923c14ff9d913c4f7dc8a3bc"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd2fd827b0ba763ac919440042302315c564fdb797294d86e8cdd4578e3bc7f3"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82085c2abec437abebf457c1d12fccb30cc8b3774a0814872511f0f0562c768c"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07fda5de378626e502b42b311b049848c2ef38784d0d67b6f30bb5008642f8eb"},
+    {file = "xxhash-3.5.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c279f0d2b34ef15f922b77966640ade58b4ccdfef1c4d94b20f2a364617a493f"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:89e66ceed67b213dec5a773e2f7a9e8c58f64daeb38c7859d8815d2c89f39ad7"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bcd51708a633410737111e998ceb3b45d3dbc98c0931f743d9bb0a209033a326"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ff2c0a34eae7df88c868be53a8dd56fbdf592109e21d4bfa092a27b0bf4a7bf"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:4e28503dccc7d32e0b9817aa0cbfc1f45f563b2c995b7a66c4c8a0d232e840c7"},
+    {file = "xxhash-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a6c50017518329ed65a9e4829154626f008916d36295b6a3ba336e2458824c8c"},
+    {file = "xxhash-3.5.0-cp313-cp313-win32.whl", hash = "sha256:53a068fe70301ec30d868ece566ac90d873e3bb059cf83c32e76012c889b8637"},
+    {file = "xxhash-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:80babcc30e7a1a484eab952d76a4f4673ff601f54d5142c26826502740e70b43"},
+    {file = "xxhash-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:4811336f1ce11cac89dcbd18f3a25c527c16311709a89313c3acaf771def2d4b"},
+    {file = "xxhash-3.5.0.tar.gz", hash = "sha256:84f2caddf951c9cbf8dc2e22a89d4ccf5d86391ac6418fe81e3c67d0cf60b45f"},
 ]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5ab9ba1ca071909f99701fa39ec8dd64891ad037b14697fbbd881941575a2e4c"
+content_hash = "sha256:82bb77c41c89ab2ef3f9d006262f2d306bec2dcf5d39527be40d10c9eea0607b"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -1027,6 +1027,34 @@ files = [
     {file = "ruff-0.9.9-py3-none-win_amd64.whl", hash = "sha256:837982ea24091d4c1700ddb2f63b7070e5baec508e43b01de013dc7eff974ff1"},
     {file = "ruff-0.9.9-py3-none-win_arm64.whl", hash = "sha256:3ac78f127517209fe6d96ab00f3ba97cafe38718b23b1db3e96d8b2d39e37ddf"},
     {file = "ruff-0.9.9.tar.gz", hash = "sha256:0062ed13f22173e85f8f7056f9a24016e692efeea8704d1a5e8011b8aa850933"},
+]
+
+[[package]]
+name = "setuptools"
+version = "78.0.2"
+requires_python = ">=3.9"
+summary = "Easily download, build, install, upgrade, and uninstall Python packages"
+groups = ["default"]
+files = [
+    {file = "setuptools-78.0.2-py3-none-any.whl", hash = "sha256:4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d"},
+    {file = "setuptools-78.0.2.tar.gz", hash = "sha256:137525e6afb9022f019d6e884a319017f9bf879a0d8783985d32cbc8683cab93"},
+]
+
+[[package]]
+name = "setuptools-scm"
+version = "8.2.0"
+requires_python = ">=3.8"
+summary = "the blessed package to manage your versions by scm tags"
+groups = ["default"]
+dependencies = [
+    "packaging>=20",
+    "setuptools>=61",
+    "tomli>=1; python_version < \"3.11\"",
+    "typing-extensions; python_version < \"3.10\"",
+]
+files = [
+    {file = "setuptools_scm-8.2.0-py3-none-any.whl", hash = "sha256:136e2b1d393d709d2bcf26f275b8dec06c48b811154167b0fd6bb002aad17d6d"},
+    {file = "setuptools_scm-8.2.0.tar.gz", hash = "sha256:a18396a1bc0219c974d1a74612b11f9dce0d5bd8b1dc55c65f6ac7fd609e8c28"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "httpx>=0.28.1",
     "pandera>=0.22.1",
+    "xxhash>=3.5.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.28.1",
     "pandera>=0.22.1",
     "xxhash>=3.5.0",
+    "setuptools-scm>=8.2.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"
@@ -58,3 +59,9 @@ tests = "pytest"
 dev = [
     "-e file:///${PROJECT_ROOT}/data#egg=data",
 ]
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"
+root = "."
+fallback_version = "0.0"

--- a/src/ma/elexon/S0142/download_raw.py
+++ b/src/ma/elexon/S0142/download_raw.py
@@ -5,11 +5,12 @@ from pathlib import Path
 import httpx
 import pandas as pd
 
+import ma.utils.conf
 import ma.utils.io
 
 LOG = ma.utils.io.get_logger(__name__)
 
-API_KEY = ma.utils.io.get_dot_env("ELEXON_API_KEY")
+API_KEY = ma.utils.conf.get_dot_env("ELEXON_API_KEY")
 BASE_URL = "https://downloads.elexonportal.co.uk/p114"
 
 

--- a/src/ma/utils/conf.py
+++ b/src/ma/utils/conf.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from setuptools_scm import get_version  # type: ignore
+
+
+def get_dot_env(key: str) -> str:
+    load_dotenv()
+    value = os.getenv(key, None)
+    if value is None:
+        raise Exception(f".env key {key} is None")
+    return value
+
+
+def get_code_version() -> str:
+    return get_version(root=Path(__file__).parent.parent.parent.parent, fallback_version="unknown")

--- a/src/ma/utils/io.py
+++ b/src/ma/utils/io.py
@@ -1,12 +1,10 @@
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Dict, Union
 
 import numpy as np
 import yaml
-from dotenv import load_dotenv
 from yaml import Dumper, ScalarNode
 
 
@@ -60,11 +58,3 @@ def to_yaml_text(dictionary: Dict) -> str:
 def to_yaml_file(dictionary: Dict, path: Path) -> None:
     with open(path, "w") as file:
         file.write(to_yaml_text(dictionary))
-
-
-def get_dot_env(key: str) -> str:
-    load_dotenv()
-    value = os.getenv(key, None)
-    if value is None:
-        raise Exception(f".env key {key} is None")
-    return value

--- a/src/ma/utils/io.py
+++ b/src/ma/utils/io.py
@@ -1,13 +1,10 @@
 import logging
 import os
-import pickle
 import sys
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Dict, Union
 
 import numpy as np
-import pandas as pd
-import xxhash
 import yaml
 from dotenv import load_dotenv
 from yaml import Dumper, ScalarNode
@@ -71,15 +68,3 @@ def get_dot_env(key: str) -> str:
     if value is None:
         raise Exception(f".env key {key} is None")
     return value
-
-
-def checksum(obj: Any) -> str:
-    hasher = xxhash.xxh64()
-    if isinstance(obj, (pd.DataFrame, pd.Series)):
-        obj = obj.to_numpy()  # Convert Pandas objects to NumPy arrays for fast processing
-    try:
-        hasher.update(pickle.dumps(obj, protocol=4))  # Protocol 4 is more efficient for large data
-    except Exception:
-        hasher.update(str(obj).encode())  # Fallback for unpickleable objects
-
-    return hasher.hexdigest()

--- a/src/ma/utils/misc.py
+++ b/src/ma/utils/misc.py
@@ -1,4 +1,13 @@
+from pathlib import Path
+
+from setuptools_scm import get_version  # type: ignore
+
+
 def truncate_string(input_string: str, max_length: int = 30, suffix: str = "...") -> str:
     if len(input_string) > max_length:
         return input_string[: max_length - len(suffix)] + suffix
     return input_string
+
+
+def get_code_version() -> str:
+    return get_version(root=Path(__file__).parent.parent.parent.parent, fallback_version="unknown")

--- a/src/ma/utils/misc.py
+++ b/src/ma/utils/misc.py
@@ -1,13 +1,4 @@
-from pathlib import Path
-
-from setuptools_scm import get_version  # type: ignore
-
-
 def truncate_string(input_string: str, max_length: int = 30, suffix: str = "...") -> str:
     if len(input_string) > max_length:
         return input_string[: max_length - len(suffix)] + suffix
     return input_string
-
-
-def get_code_version() -> str:
-    return get_version(root=Path(__file__).parent.parent.parent.parent, fallback_version="unknown")

--- a/src/ma/utils/pandas.py
+++ b/src/ma/utils/pandas.py
@@ -9,7 +9,7 @@ import pandera as pa
 import xxhash
 from pandera.engines import pandas_engine
 
-from ma.utils.misc import get_code_version
+from ma.utils.conf import get_code_version
 
 
 def select_columns(df: pd.DataFrame, exclude: list) -> pd.DataFrame:

--- a/tests/ma/elexon/metering_data/test_metering_by_time.py
+++ b/tests/ma/elexon/metering_data/test_metering_by_time.py
@@ -30,39 +30,47 @@ def test_transforms() -> None:
     assert day_1_daily["settlement_period_count"].unique() == 48
     day_2_daily = day_2_half_hourly.transform_to_daily()
 
-    monthly = MeteringDataDaily.aggregate_to_monthly([day_1_daily.df, day_2_daily.df])
+    monthly = MeteringDataDaily.aggregate_to_monthly([day_1_daily, day_2_daily])
     assert len(monthly.df) == 1
     assert monthly["bm_unit_metered_volume_mwh"].sum() == approx(day_1_s0142_bm_mwh_sum + day_2_s0142_bm_mwh_sum)
     assert monthly["day_count"].unique() == 2
 
-    yearly = MeteringDataMonthly.aggregate_to_yearly([monthly.df])
+    yearly = MeteringDataMonthly.aggregate_to_yearly([monthly])
     assert len(yearly.df) == 1
     assert yearly["bm_unit_metered_volume_mwh"].sum() == approx(day_1_s0142_bm_mwh_sum + day_2_s0142_bm_mwh_sum)
     assert yearly["month_count"].unique() == 1
 
 
+def get_daily() -> MeteringDataDaily:
+    return (
+        ProcessedS0142(data.register.S0142_20230330_SF_20230425121906_GOLD_CSV)
+        .transform_to_half_hourly_by_bmu()
+        .transform_to_half_hourly()
+        .transform_to_daily()
+    )
+
+
 def test_transform_daily_to_monthly_assert_single_month() -> None:
+    day_1 = get_daily()
+    day_2_df = day_1.df
+    day_2_df.index = day_2_df.index + pd.DateOffset(months=1)
+    day_2 = MeteringDataDaily(day_2_df)
+
     with pytest.raises(AssertionError, match="span multiple"):
-        MeteringDataDaily.aggregate_to_monthly(
-            [
-                pd.DataFrame({"value": range(48)}, index=pd.date_range(f"2025-{m:02d}-11", periods=48, freq="30min"))
-                for m in [3, 4]
-            ]
-        )
+        MeteringDataDaily.aggregate_to_monthly([day_1, day_2])
 
 
 def test_transform_monthly_to_yearly_assert_single_year() -> None:
+    month_1 = MeteringDataMonthly(get_daily().df)
+    month_2_df = month_1.df
+    month_2_df.index = month_2_df.index + pd.DateOffset(years=1)
+    month_2 = MeteringDataMonthly(month_2_df)
     with pytest.raises(AssertionError, match="span multiple"):
-        MeteringDataMonthly.aggregate_to_yearly(
-            [
-                pd.DataFrame({"value": range(30)}, index=pd.date_range(f"{y}-03-01", periods=30, freq="D"))
-                for y in [2025, 2026]
-            ]
-        )
+        MeteringDataMonthly.aggregate_to_yearly([month_1, month_2])
 
 
 def test_transform_assert_no_duplicate_timestamps() -> None:
+    day_1 = get_daily()
+    day_2 = MeteringDataDaily(day_1.df)
     with pytest.raises(AssertionError, match="duplicate"):
-        MeteringDataMonthly.aggregate_to_yearly(
-            [pd.DataFrame({"value": range(30)}, index=pd.date_range("2025-03-01", periods=30, freq="D"))] * 2
-        )
+        MeteringDataDaily.aggregate_to_monthly([day_1, day_2])

--- a/tests/ma/utils/test_conf.py
+++ b/tests/ma/utils/test_conf.py
@@ -1,0 +1,7 @@
+from ma.utils.conf import get_code_version
+
+
+def test_get_code_version() -> None:
+    version = get_code_version()
+    assert version is not None
+    assert version != "unknown"

--- a/tests/ma/utils/test_pandas_data_frame_asset.py
+++ b/tests/ma/utils/test_pandas_data_frame_asset.py
@@ -155,3 +155,14 @@ def test_from_file_skiprows() -> None:
 
     df = Asset(Path(f"{Path(__file__).parent}/test.csv"))
     assert len(df.df) == 1
+
+
+def test_metadata() -> None:
+    class Asset(DataFrameAsset):
+        schema = dict(col_a=CS(check=pa.Column(int)), col_b=CS(check=pa.Column(str)))
+
+    df = Asset(copy.deepcopy(DF_RAW))
+    metadata = df.metadata
+    assert set(metadata.keys()) == set(["type", "rows", "checksum", "ma_version"])
+    assert metadata["type"] == "Asset"
+    assert metadata["rows"] == "5"


### PR DESCRIPTION
~~This was in `matched-dagster` but I'm moving it here so it can be used in `matched-data` too (it's not actually in use yet, but will be when we're persisting to parquet or similar, rather than csv).~~

This PR introduces DataFrameAsset.metadata