### PR TITLE
Introduce ma.utils.conf

### DIFF
--- a/src/ma/elexon/S0142/download_raw.py
+++ b/src/ma/elexon/S0142/download_raw.py
@@ -5,11 +5,12 @@ from pathlib import Path
 import httpx
 import pandas as pd
 
+import ma.utils.conf
 import ma.utils.io
 
 LOG = ma.utils.io.get_logger(__name__)
 
-API_KEY = ma.utils.io.get_dot_env("ELEXON_API_KEY")
+API_KEY = ma.utils.conf.get_dot_env("ELEXON_API_KEY")
 BASE_URL = "https://downloads.elexonportal.co.uk/p114"
 
 

--- a/src/ma/utils/conf.py
+++ b/src/ma/utils/conf.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from setuptools_scm import get_version  # type: ignore
+
+
+def get_dot_env(key: str) -> str:
+    load_dotenv()
+    value = os.getenv(key, None)
+    if value is None:
+        raise Exception(f".env key {key} is None")
+    return value
+
+
+def get_code_version() -> str:
+    return get_version(root=Path(__file__).parent.parent.parent.parent, fallback_version="unknown")

--- a/src/ma/utils/io.py
+++ b/src/ma/utils/io.py
@@ -1,12 +1,10 @@
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Dict, Union
 
 import numpy as np
 import yaml
-from dotenv import load_dotenv
 from yaml import Dumper, ScalarNode
 
 
@@ -60,11 +58,3 @@ def to_yaml_text(dictionary: Dict) -> str:
 def to_yaml_file(dictionary: Dict, path: Path) -> None:
     with open(path, "w") as file:
         file.write(to_yaml_text(dictionary))
-
-
-def get_dot_env(key: str) -> str:
-    load_dotenv()
-    value = os.getenv(key, None)
-    if value is None:
-        raise Exception(f".env key {key} is None")
-    return value

--- a/src/ma/utils/misc.py
+++ b/src/ma/utils/misc.py
@@ -1,13 +1,4 @@
-from pathlib import Path
-
-from setuptools_scm import get_version  # type: ignore
-
-
 def truncate_string(input_string: str, max_length: int = 30, suffix: str = "...") -> str:
     if len(input_string) > max_length:
         return input_string[: max_length - len(suffix)] + suffix
     return input_string
-
-
-def get_code_version() -> str:
-    return get_version(root=Path(__file__).parent.parent.parent.parent, fallback_version="unknown")

--- a/src/ma/utils/pandas.py
+++ b/src/ma/utils/pandas.py
@@ -9,7 +9,7 @@ import pandera as pa
 import xxhash
 from pandera.engines import pandas_engine
 
-from ma.utils.misc import get_code_version
+from ma.utils.conf import get_code_version
 
 
 def select_columns(df: pd.DataFrame, exclude: list) -> pd.DataFrame:

--- a/tests/ma/utils/test_conf.py
+++ b/tests/ma/utils/test_conf.py
@@ -1,0 +1,7 @@
+from ma.utils.conf import get_code_version
+
+
+def test_get_code_version() -> None:
+    version = get_code_version()
+    assert version is not None
+    assert version != "unknown"


### PR DESCRIPTION
Introduce `ma.utils.conf` for utilities that relate to the management or generation of configuration. This pattern is in keeping with that in `matched-dagster`.